### PR TITLE
Fix timestamp Field in Breadcrumb model

### DIFF
--- a/VibeCodingBreadcrumbDemo/backend/app/main.py
+++ b/VibeCodingBreadcrumbDemo/backend/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Dict
 from datetime import datetime
 
@@ -9,7 +9,7 @@ class Breadcrumb(BaseModel):
     conversation_id: str
     step: int
     content: str
-    timestamp: datetime = datetime.utcnow()
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
 
 # Simple in-memory storage for demo purposes
 conversations: Dict[str, List[Breadcrumb]] = {}


### PR DESCRIPTION
## Summary
- use `Field(default_factory=datetime.utcnow)` for `timestamp`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860001365f4832083ef0c3e0eedc30f